### PR TITLE
Fix regression in `settings` property handling

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -53,7 +53,7 @@ function upower_battery.factory(args)
 			bat_now.time = "N/A"
 		end
 		widget = bat.widget
-		settings()
+		settings(bat_now, widget)
 	end
 
 	upower_battery.display_device = upower.Client():get_display_device()


### PR DESCRIPTION
This fixes problem with custom `settings` handling functions, which expect to receive `bat_now` and `widget` arguments when called. See also #1 and [this comment](https://github.com/berlam/awesome-upower-battery/commit/fc089cb674741ab928756c47946f72ce73ec3174#commitcomment-25556979).